### PR TITLE
Fix example relative path to the lib

### DIFF
--- a/example/challenge_example/framework/Cargo.toml
+++ b/example/challenge_example/framework/Cargo.toml
@@ -25,7 +25,7 @@ move-binary-format = { git = "https://github.com/otter-sec/aptos-test-adapter", 
 
 # apt-ctf-framework = { git = "https://github.com/otter-sec/apt-ctf-framework" }
 aptos-crypto = { git = "https://github.com/otter-sec/aptos-test-adapter", package="aptos-crypto", branch = "main" }
-apt-ctf-framework = { path = "../../../../apt-ctf-framework" }
+apt-ctf-framework = { path = "../../../" }
 # aptos-crypto = { path = "../../../../../aptos-core/crates/aptos-crypto" }
 
 


### PR DESCRIPTION
This repository will be checked out with the default name `aptos-ctf-framework` and the dependency `apt-ctf-framework = "0.1.0"` is not available yet. So I suggest using relative path to the parent folder for the current example.